### PR TITLE
Added Auth0 authorization (will finish after class)

### DIFF
--- a/API/endpoints.py
+++ b/API/endpoints.py
@@ -4,24 +4,17 @@ The endpoint called `endpoints` will return all available endpoints.
 """
 
 from http import HTTPStatus
-from flask import Flask, request, jsonify, _request_ctx_stack
+from flask import Flask
 from flask_restx import Resource, Api, reqparse
 from flask_cors import cross_origin
 import werkzeug.exceptions as wz
-import json
-import os
-from six.moves.urllib.request import urlopen
-from functools import wraps
-from jose import jwt
 
 import db.data as db
+import server
 
 app = Flask(__name__)
 api = Api(app)
 
-AUTH0_DOMAIN = os.environ.get("AUTH0_DOMAIN")
-API_AUDIENCE = os.environ.get("AUTH0_API_AUDIENCE")
-ALGORITHMS = ["RS256"]
 
 spotParser = reqparse.RequestParser()
 spotParser.add_argument('spotName', type=str, location='form')
@@ -41,114 +34,6 @@ factorParser.add_argument('factorAvailability', type=int, location='form')
 factorParser.add_argument('factorNoiseLevel', type=int, location='form')
 factorParser.add_argument('factorTemperature', type=int, location='form')
 factorParser.add_argument('factorAmbiance', type=int, location='form')
-
-
-# Error handler
-class AuthError(Exception):
-    def __init__(self, error, status_code):
-        self.error = error
-        self.status_code = status_code
-
-
-@app.errorhandler(AuthError)
-def handle_auth_error(ex):
-    response = jsonify(ex.error)
-    response.status_code = ex.status_code
-    return response
-
-
-# Format error response and append status code
-def get_token_auth_header():
-    """Obtains the Access Token from the Authorization Header
-    """
-    auth = request.headers.get("Authorization", None)
-    if not auth:
-        raise AuthError({"code": "authorization_header_missing",
-                        "description":
-                            "Authorization header is expected"}, 401)
-
-    parts = auth.split()
-
-    if parts[0].lower() != "bearer":
-        raise AuthError({"code": "invalid_header",
-                        "description":
-                            "Authorization header must start with"
-                            " Bearer"}, 401)
-    elif len(parts) == 1:
-        raise AuthError({"code": "invalid_header",
-                        "description": "Token not found"}, 401)
-    elif len(parts) > 2:
-        raise AuthError({"code": "invalid_header",
-                        "description":
-                            "Authorization header must be"
-                            " Bearer token"}, 401)
-
-    token = parts[1]
-    return token
-
-
-def requires_auth(f):
-    """Determines if the Access Token is valid
-    """
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        token = get_token_auth_header()
-        jsonurl = urlopen("https://"+AUTH0_DOMAIN+"/.well-known/jwks.json")
-        jwks = json.loads(jsonurl.read())
-        unverified_header = jwt.get_unverified_header(token)
-        rsa_key = {}
-        for key in jwks["keys"]:
-            if key["kid"] == unverified_header["kid"]:
-                rsa_key = {
-                    "kty": key["kty"],
-                    "kid": key["kid"],
-                    "use": key["use"],
-                    "n": key["n"],
-                    "e": key["e"]
-                }
-        if rsa_key:
-            try:
-                payload = jwt.decode(
-                    token,
-                    rsa_key,
-                    algorithms=ALGORITHMS,
-                    audience=API_AUDIENCE,
-                    issuer="https://"+AUTH0_DOMAIN+"/"
-                )
-            except jwt.ExpiredSignatureError:
-                raise AuthError({"code": "token_expired",
-                                "description": "token is expired"}, 401)
-            except jwt.JWTClaimsError:
-                raise AuthError({"code": "invalid_claims",
-                                "description":
-                                    "incorrect claims,"
-                                    "please check the audience and issuer"}, 401)  # noqa: E501
-            except Exception:
-                raise AuthError({"code": "invalid_header",
-                                "description":
-                                    "Unable to parse authentication"
-                                    " token."}, 401)
-
-            _request_ctx_stack.top.current_user = payload
-            return f(*args, **kwargs)
-        raise AuthError({"code": "invalid_header",
-                        "description": "Unable to find appropriate key"}, 401)
-    return decorated
-
-
-def requires_scope(required_scope):
-    """Determines if the required scope is present in the Access Token
-    Args:
-        required_scope (str): The scope required to access the resource
-    """
-    token = get_token_auth_header()
-    unverified_claims = jwt.get_unverified_claims(token)
-    if unverified_claims.get("scope"):
-        token_scopes = unverified_claims["scope"].split()
-        for token_scope in token_scopes:
-            if token_scope == required_scope:
-                return True
-    return False
 
 
 @api.route('/hello')
@@ -185,7 +70,7 @@ class Spot(Resource):
     @api.doc(parser=spotParser)
     @cross_origin(headers=["Content-Type", "Authorization"])
     @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
-    @requires_auth
+    @server.requires_auth
     def post(self):
         """
         Creates a new spot
@@ -225,7 +110,7 @@ class SpotDetail(Resource):
     @api.doc(parser=spotParser)
     @cross_origin(headers=["Content-Type", "Authorization"])
     @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
-    @requires_auth
+    @server.requires_auth
     def put(self, spot_id):
         """
         Update a spot
@@ -247,7 +132,7 @@ class SpotDetail(Resource):
     @api.response(HTTPStatus.NOT_FOUND, 'Not Found')
     @cross_origin(headers=["Content-Type", "Authorization"])
     @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
-    @requires_auth
+    @server.requires_auth
     def delete(self, spot_id):
         """
         Delete a spot
@@ -269,7 +154,7 @@ class SpotUpdateFactor(Resource):
     @api.doc(parser=factorParser)
     @cross_origin(headers=["Content-Type", "Authorization"])
     @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
-    @requires_auth
+    @server.requires_auth
     def put(self, spot_id):
         """
         Update a spot factor
@@ -289,7 +174,7 @@ class Review(Resource):
     @api.doc(parser=reviewParser)
     @cross_origin(headers=["Content-Type", "Authorization"])
     @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
-    @requires_auth
+    @server.requires_auth
     def post(self):
         """
         Creates a new review
@@ -311,7 +196,7 @@ class ReviewDetail(Resource):
     @api.response(HTTPStatus.NOT_ACCEPTABLE, 'A duplicate key')
     @cross_origin(headers=["Content-Type", "Authorization"])
     @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
-    @requires_auth
+    @server.requires_auth
     def delete(self, review_id):
         """
         Deletes a new review

--- a/API/endpoints.py
+++ b/API/endpoints.py
@@ -4,14 +4,24 @@ The endpoint called `endpoints` will return all available endpoints.
 """
 
 from http import HTTPStatus
-from flask import Flask
+from flask import Flask, request, jsonify, _request_ctx_stack
 from flask_restx import Resource, Api, reqparse
+from flask_cors import cross_origin
 import werkzeug.exceptions as wz
+import json
+import os
+from six.moves.urllib.request import urlopen
+from functools import wraps
+from jose import jwt
 
 import db.data as db
 
 app = Flask(__name__)
 api = Api(app)
+
+AUTH0_DOMAIN = os.environ.get("AUTH0_DOMAIN")
+API_AUDIENCE = os.environ.get("AUTH0_API_AUDIENCE")
+ALGORITHMS = ["RS256"]
 
 spotParser = reqparse.RequestParser()
 spotParser.add_argument('spotName', type=str, location='form')
@@ -33,6 +43,114 @@ factorParser.add_argument('factorTemperature', type=int, location='form')
 factorParser.add_argument('factorAmbiance', type=int, location='form')
 
 
+# Error handler
+class AuthError(Exception):
+    def __init__(self, error, status_code):
+        self.error = error
+        self.status_code = status_code
+
+
+@app.errorhandler(AuthError)
+def handle_auth_error(ex):
+    response = jsonify(ex.error)
+    response.status_code = ex.status_code
+    return response
+
+
+# Format error response and append status code
+def get_token_auth_header():
+    """Obtains the Access Token from the Authorization Header
+    """
+    auth = request.headers.get("Authorization", None)
+    if not auth:
+        raise AuthError({"code": "authorization_header_missing",
+                        "description":
+                            "Authorization header is expected"}, 401)
+
+    parts = auth.split()
+
+    if parts[0].lower() != "bearer":
+        raise AuthError({"code": "invalid_header",
+                        "description":
+                            "Authorization header must start with"
+                            " Bearer"}, 401)
+    elif len(parts) == 1:
+        raise AuthError({"code": "invalid_header",
+                        "description": "Token not found"}, 401)
+    elif len(parts) > 2:
+        raise AuthError({"code": "invalid_header",
+                        "description":
+                            "Authorization header must be"
+                            " Bearer token"}, 401)
+
+    token = parts[1]
+    return token
+
+
+def requires_auth(f):
+    """Determines if the Access Token is valid
+    """
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = get_token_auth_header()
+        jsonurl = urlopen("https://"+AUTH0_DOMAIN+"/.well-known/jwks.json")
+        jwks = json.loads(jsonurl.read())
+        unverified_header = jwt.get_unverified_header(token)
+        rsa_key = {}
+        for key in jwks["keys"]:
+            if key["kid"] == unverified_header["kid"]:
+                rsa_key = {
+                    "kty": key["kty"],
+                    "kid": key["kid"],
+                    "use": key["use"],
+                    "n": key["n"],
+                    "e": key["e"]
+                }
+        if rsa_key:
+            try:
+                payload = jwt.decode(
+                    token,
+                    rsa_key,
+                    algorithms=ALGORITHMS,
+                    audience=API_AUDIENCE,
+                    issuer="https://"+AUTH0_DOMAIN+"/"
+                )
+            except jwt.ExpiredSignatureError:
+                raise AuthError({"code": "token_expired",
+                                "description": "token is expired"}, 401)
+            except jwt.JWTClaimsError:
+                raise AuthError({"code": "invalid_claims",
+                                "description":
+                                    "incorrect claims,"
+                                    "please check the audience and issuer"}, 401)  # noqa: E501
+            except Exception:
+                raise AuthError({"code": "invalid_header",
+                                "description":
+                                    "Unable to parse authentication"
+                                    " token."}, 401)
+
+            _request_ctx_stack.top.current_user = payload
+            return f(*args, **kwargs)
+        raise AuthError({"code": "invalid_header",
+                        "description": "Unable to find appropriate key"}, 401)
+    return decorated
+
+
+def requires_scope(required_scope):
+    """Determines if the required scope is present in the Access Token
+    Args:
+        required_scope (str): The scope required to access the resource
+    """
+    token = get_token_auth_header()
+    unverified_claims = jwt.get_unverified_claims(token)
+    if unverified_claims.get("scope"):
+        token_scopes = unverified_claims["scope"].split()
+        for token_scope in token_scopes:
+            if token_scope == required_scope:
+                return True
+    return False
+
+
 @api.route('/hello')
 class HelloWorld(Resource):
     """
@@ -51,6 +169,7 @@ class HelloWorld(Resource):
 class Spot(Resource):
     @api.response(HTTPStatus.OK, 'Success')
     @api.response(HTTPStatus.NOT_FOUND, 'Not Found')
+    @cross_origin(headers=["Content-Type", "Authorization"])  # noqa: E501
     def get(self):
         """
         Returns all spots
@@ -64,6 +183,9 @@ class Spot(Resource):
     @api.response(HTTPStatus.OK, 'Success')
     @api.response(HTTPStatus.NOT_ACCEPTABLE, 'A duplicate key')
     @api.doc(parser=spotParser)
+    @cross_origin(headers=["Content-Type", "Authorization"])
+    @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
+    @requires_auth
     def post(self):
         """
         Creates a new spot
@@ -84,6 +206,7 @@ class SpotDetail(Resource):
     """
     @api.response(HTTPStatus.OK, 'Success')
     @api.response(HTTPStatus.NOT_FOUND, 'Not Found')
+    @cross_origin(headers=["Content-Type", "Authorization"])
     def get(self, spot_id):
         """
         Returns a details of a spot
@@ -100,6 +223,9 @@ class SpotDetail(Resource):
     @api.response(HTTPStatus.OK, 'Success')
     @api.response(HTTPStatus.NOT_FOUND, 'Not Found')
     @api.doc(parser=spotParser)
+    @cross_origin(headers=["Content-Type", "Authorization"])
+    @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
+    @requires_auth
     def put(self, spot_id):
         """
         Update a spot
@@ -119,6 +245,9 @@ class SpotDetail(Resource):
     """
     @api.response(HTTPStatus.OK, 'Success')
     @api.response(HTTPStatus.NOT_FOUND, 'Not Found')
+    @cross_origin(headers=["Content-Type", "Authorization"])
+    @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
+    @requires_auth
     def delete(self, spot_id):
         """
         Delete a spot
@@ -138,6 +267,9 @@ class SpotUpdateFactor(Resource):
     @api.response(HTTPStatus.OK, 'Success')
     @api.response(HTTPStatus.NOT_FOUND, 'Not Found')
     @api.doc(parser=factorParser)
+    @cross_origin(headers=["Content-Type", "Authorization"])
+    @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
+    @requires_auth
     def put(self, spot_id):
         """
         Update a spot factor
@@ -155,6 +287,9 @@ class Review(Resource):
     @api.response(HTTPStatus.OK, 'Success')
     @api.response(HTTPStatus.NOT_ACCEPTABLE, 'A duplicate key')
     @api.doc(parser=reviewParser)
+    @cross_origin(headers=["Content-Type", "Authorization"])
+    @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
+    @requires_auth
     def post(self):
         """
         Creates a new review
@@ -174,6 +309,9 @@ class Review(Resource):
 class ReviewDetail(Resource):
     @api.response(HTTPStatus.OK, 'Success')
     @api.response(HTTPStatus.NOT_ACCEPTABLE, 'A duplicate key')
+    @cross_origin(headers=["Content-Type", "Authorization"])
+    @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])  # noqa: E501
+    @requires_auth
     def delete(self, review_id):
         """
         Deletes a new review
@@ -189,6 +327,7 @@ class ReviewDetail(Resource):
 class ReviewSpot(Resource):
     @api.response(HTTPStatus.OK, 'Success')
     @api.response(HTTPStatus.NOT_ACCEPTABLE, 'A duplicate key')
+    @cross_origin(headers=["Content-Type", "Authorization"])
     def get(self, spot_id):
         """
         Get review for specific spot

--- a/API/server.py
+++ b/API/server.py
@@ -1,0 +1,128 @@
+"""
+This is the file containing all of the endpoints for our flask app.
+The endpoint called `endpoints` will return all available endpoints.
+"""
+
+from flask import Flask, request, jsonify, _request_ctx_stack
+from flask_restx import Api
+import json
+import os
+from six.moves.urllib.request import urlopen
+from functools import wraps
+from jose import jwt
+
+
+app = Flask(__name__)
+api = Api(app)
+
+AUTH0_DOMAIN = os.environ.get("AUTH0_DOMAIN")
+API_AUDIENCE = os.environ.get("AUTH0_API_AUDIENCE")
+ALGORITHMS = ["RS256"]
+
+
+# Error handler
+class AuthError(Exception):
+    def __init__(self, error, status_code):
+        self.error = error
+        self.status_code = status_code
+
+
+@app.errorhandler(AuthError)
+def handle_auth_error(ex):
+    response = jsonify(ex.error)
+    response.status_code = ex.status_code
+    return response
+
+
+# Format error response and append status code
+def get_token_auth_header():
+    """Obtains the Access Token from the Authorization Header
+    """
+    auth = request.headers.get("Authorization", None)
+    if not auth:
+        raise AuthError({"code": "authorization_header_missing",
+                        "description":
+                            "Authorization header is expected"}, 401)
+
+    parts = auth.split()
+
+    if parts[0].lower() != "bearer":
+        raise AuthError({"code": "invalid_header",
+                        "description":
+                            "Authorization header must start with"
+                            " Bearer"}, 401)
+    elif len(parts) == 1:
+        raise AuthError({"code": "invalid_header",
+                        "description": "Token not found"}, 401)
+    elif len(parts) > 2:
+        raise AuthError({"code": "invalid_header",
+                        "description":
+                            "Authorization header must be"
+                            " Bearer token"}, 401)
+
+    token = parts[1]
+    return token
+
+
+def requires_auth(f):
+    """Determines if the Access Token is valid
+    """
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = get_token_auth_header()
+        jsonurl = urlopen("https://"+AUTH0_DOMAIN+"/.well-known/jwks.json")
+        jwks = json.loads(jsonurl.read())
+        unverified_header = jwt.get_unverified_header(token)
+        rsa_key = {}
+        for key in jwks["keys"]:
+            if key["kid"] == unverified_header["kid"]:
+                rsa_key = {
+                    "kty": key["kty"],
+                    "kid": key["kid"],
+                    "use": key["use"],
+                    "n": key["n"],
+                    "e": key["e"]
+                }
+        if rsa_key:
+            try:
+                payload = jwt.decode(
+                    token,
+                    rsa_key,
+                    algorithms=ALGORITHMS,
+                    audience=API_AUDIENCE,
+                    issuer="https://"+AUTH0_DOMAIN+"/"
+                )
+            except jwt.ExpiredSignatureError:
+                raise AuthError({"code": "token_expired",
+                                "description": "token is expired"}, 401)
+            except jwt.JWTClaimsError:
+                raise AuthError({"code": "invalid_claims",
+                                "description":
+                                    "incorrect claims,"
+                                    "please check the audience and issuer"}, 401)  # noqa: E501
+            except Exception:
+                raise AuthError({"code": "invalid_header",
+                                "description":
+                                    "Unable to parse authentication"
+                                    " token."}, 401)
+
+            _request_ctx_stack.top.current_user = payload
+            return f(*args, **kwargs)
+        raise AuthError({"code": "invalid_header",
+                        "description": "Unable to find appropriate key"}, 401)
+    return decorated
+
+
+def requires_scope(required_scope):
+    """Determines if the required scope is present in the Access Token
+    Args:
+        required_scope (str): The scope required to access the resource
+    """
+    token = get_token_auth_header()
+    unverified_claims = jwt.get_unverified_claims(token)
+    if unverified_claims.get("scope"):
+        token_scopes = unverified_claims["scope"].split()
+        for token_scope in token_scopes:
+            if token_scope == required_scope:
+                return True
+    return False

--- a/API/tests/test_endpoints.py
+++ b/API/tests/test_endpoints.py
@@ -2,13 +2,18 @@
 This file holds the tests for endpoints.py.
 """
 
+from email import header
 from unittest import TestCase, skip
 from urllib import response 
 from flask_restx import Resource, Api
+import os
 
 import datetime
 import API.endpoints as ep
 import db.data as db
+
+BEARER_TEST_TOKEN = os.environ.get("BEARER_TEST_TOKEN")
+bearer = f"Bearer {BEARER_TEST_TOKEN}"
 
 class EndpointTestCase(TestCase):
     def setUp(self):
@@ -28,56 +33,58 @@ class EndpointTestCase(TestCase):
             "reviewText": "wow what a great app", 
             "reviewRating": "5"
         }
+        self.headers = { 'authorization': bearer }
+
     
     def tearDown(self):
         print("Tear Down")
 
     def test_hello(self):
-        response = self.client.get("/hello")
+        response = self.client.get("/hello", headers=self.headers)
         print(response.data)
         self.assertEqual(response.status_code, 200)
         
     def test_get_all_spots(self):
-        response = self.client.get("/spot")
+        response = self.client.get("/spot", headers=self.headers)
         print(response.data)
         self.assertEqual(response.status_code, 200)
         
     def test_create_update_delete_spot(self):
-        response = self.client.post("/spot", data=self.spotData)
+        response = self.client.post("/spot", data=self.spotData, headers=self.headers)
         spot_id = response.data.decode("utf-8").strip().strip("\"")
         print("Test Create Spot", spot_id)
         self.assertEqual(response.status_code, 200)
         
-        response = self.client.get(f"/spot/{spot_id}")
+        response = self.client.get(f"/spot/{spot_id}", headers=self.headers)
         print("Test Get Spot", response.data)
         self.assertEqual(response.status_code, 200)
 
-        response = self.client.put(f"/spot/{spot_id}", data=self.updatedSpotData)
+        response = self.client.put(f"/spot/{spot_id}", data=self.updatedSpotData, headers=self.headers)
         print("Test Update Spot", response.data)
         self.assertEqual(response.status_code, 200)
         
-        response = self.client.delete(f"/spot/{spot_id}")
+        response = self.client.delete(f"/spot/{spot_id}", headers=self.headers)
         print("Test Delete Spot", response.data)
         self.assertEqual(response.status_code, 200)
         
     def test_create_review(self):
-        response = self.client.post("/spot", data=self.spotData)
+        response = self.client.post("/spot", data=self.spotData, headers=self.headers)
         print(response.data)
         spot_id = response.data.decode("utf-8").strip().strip("\"")
         print("Test Create Review (Make Spot First)", spot_id)
         self.assertEqual(response.status_code, 200)
         
         self.reviewData["spotID"] = spot_id
-        response = self.client.post("/review", data=self.reviewData)
+        response = self.client.post("/review", data=self.reviewData, headers=self.headers)
         review_id = response.data.decode("utf-8").strip().strip("\"")
         print("Test Create Review", review_id)
         print(response.data)
         self.assertEqual(response.status_code, 200)
         
-        response = self.client.get(f"/review/{spot_id}")
+        response = self.client.get(f"/review/{spot_id}", headers=self.headers)
         print("Test Get Review", response.data)
         self.assertEqual(response.status_code, 200)
 
-        response = self.client.delete(f"/review/{review_id}")
+        response = self.client.delete(f"/review/{review_id}", headers=self.headers)
         print("Test Delete Review", response.data)
         self.assertEqual(response.status_code, 200)

--- a/db/db_connect.py
+++ b/db/db_connect.py
@@ -85,7 +85,7 @@ def get_all_spots():
             update_spot_factor(doc["_id"], spot_document)
         json_dump = json.dumps(doc, default=bsutil.default)
         output_spots.append(json.loads(json_dump))
-    return output_spots
+    return json.dumps(output_spots)
 
 
 def create_spot(spot_document):
@@ -192,7 +192,7 @@ def get_review_by_spot(spot_id):
     for review in review_cursor:
         json_dump = json.dumps(review, default=bsutil.default)
         reviews.append(json.loads(json_dump))
-    return reviews
+    return json.dumps(reviews)
 
 
 def get_spot_factor(spot_id, factorName):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 flask
 flask-restx
+flask-cors
 gunicorn
 werkzeug
 pymongo[srv]
 python-dotenv
+python-jose
+six


### PR DESCRIPTION
# Pull Request 

## Description

Added backend authorization functions according to [documentation](https://auth0.com/docs/quickstart/backend/python/01-authorization) 
Updated authorization headers for tests 
Needed to change get functions to return json (was returning list)


todo:
set up environment variables (`AUTH0_DOMAIN`, `AUTH0_API_AUDIENCE`, `BEARER_TEST_TOKEN`) for heroku and github 
use jsonify instead of json dump and load
Create test to check errors for requests without auth headers
reuse code (repeatedly set headers on endpoints)
Allow backend to set headers when accessing endpoints through server 
  - When testing endpoints manually (`./local.sh`) I got 401 auth errors because our BE can't set headers 

Fixes #8 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran existing tests and ./local.sh
