### PR TITLE
draft for error handling

### DIFF
--- a/API/tests/test_endpoints.py
+++ b/API/tests/test_endpoints.py
@@ -3,7 +3,6 @@ This file holds the tests for endpoints.py.
 """
 
 from unittest import TestCase
-
 import API.endpoints as ep
 from API.security.utils import get_auth0_token
 
@@ -29,6 +28,17 @@ class EndpointTestCase(TestCase):
         }
         self.headers = {"authorization": bearer}
         self.bad_id = "000000000000000000000000"
+        self.factor_form = {                
+            "factorDate": "2022-02-23",
+            "factorValue": "4",
+            "factorNumOfInputs": "1"
+        }
+        self.factor = {
+            "factorAvailability": self.factor_form,
+            "factorNoiseLevel": self.factor_form,
+            "factorTemperature": self.factor_form,
+            "factorAmbiance": self.factor_form
+        }
     
     def tearDown(self):
         print("Tear Down")
@@ -43,14 +53,14 @@ class EndpointTestCase(TestCase):
         print(response.data)
         self.assertEqual(response.status_code, 200)
         
-    def test_create_update_delete_spot(self):
+    def test_spot_crud(self):
         response = self.client.post("/spot", data=self.spotData, headers=self.headers)
         spot_id = response.data.decode("utf-8").strip().strip("\"")
         print("Test Create Spot", spot_id)
         self.assertEqual(response.status_code, 200)
         
         response = self.client.get(f"/spot/{spot_id}", headers=self.headers)
-        print("Test Get Spot", response.data)
+        print("Test Get Spot Detail", response.data)
         self.assertEqual(response.status_code, 200)
 
         response = self.client.put(f"/spot/{spot_id}", data=self.updatedSpotData, headers=self.headers)
@@ -61,7 +71,7 @@ class EndpointTestCase(TestCase):
         print("Test Delete Spot", response.data)
         self.assertEqual(response.status_code, 200)
         
-    def test_create_review(self):
+    def test_review_crud(self):
         response = self.client.post("/spot", data=self.spotData, headers=self.headers)
         print(response.data)
         spot_id = response.data.decode("utf-8").strip().strip("\"")
@@ -76,11 +86,19 @@ class EndpointTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         
         response = self.client.get(f"/review/{spot_id}", headers=self.headers)
-        print("Test Get Review", response.data)
+        print("Test Get Review By Spot", response.data)
         self.assertEqual(response.status_code, 200)
 
         response = self.client.delete(f"/review/{review_id}", headers=self.headers)
         print("Test Delete Review", response.data)
+        self.assertEqual(response.status_code, 200)
+        
+    def test_factor_crud(self):
+        response = self.client.post("/spot", data=self.spotData, headers=self.headers)
+        spot_id = response.data.decode("utf-8").strip().strip("\"")
+        self.assertEqual(response.status_code, 200)
+        
+        response = self.client.put(f"/spot/factor/{spot_id}", json=self.factor, headers=self.headers)
         self.assertEqual(response.status_code, 200)
 
     def test_unauthorized_bad_requests(self):
@@ -108,4 +126,32 @@ class EndpointTestCase(TestCase):
         self.assertEqual(response.status_code, 404)
         
         response = self.client.delete(f"/spot/{self.bad_id}", headers=self.headers)
+        self.assertEqual(response.status_code, 404)
+
+    def test_bad_put(self): 
+        response = self.client.put(f"/spot/{self.bad_id}", data=self.updatedSpotData, headers=self.headers)
+        print("Test Bad Spot Put")
+        self.assertEqual(response.status_code, 404)
+        
+        response = self.client.get(f"/spot/{self.bad_id}", headers=self.headers)
+        # make sure it wasn't created
+        self.assertEqual(response.status_code, 404)
+
+        print("Test Bad Factor Put")
+        response = self.client.put(f"/spot/factor/{self.bad_id}", json=self.factor, headers=self.headers)
+        self.assertEqual(response.status_code, 404)
+
+    def test_bad_get_by_id(self): 
+        response = self.client.get(f"/spot/{self.bad_id}", headers=self.headers)
+        print("Test Bad Get Spot Detail", response.data)
+        self.assertEqual(response.status_code, 404)
+        
+        response = self.client.get(f"/review/{self.bad_id}", headers=self.headers)
+        print("Test Bad Get Review", response.data)
+        self.assertEqual(response.status_code, 404)
+
+    def test_bad_post(self):
+        self.reviewData["spotID"] = self.bad_id
+        response = self.client.post("/review", data=self.reviewData, headers=self.headers)
+        print("Test Bad Create Review", response)
         self.assertEqual(response.status_code, 404)

--- a/db/data.py
+++ b/db/data.py
@@ -129,8 +129,13 @@ def update_individual_spot_factor(spot_id, factorName, factorRating):
 
 
 def update_spot_factors(spot_id, factorArgs):
+    spot_id = dbc.convert_to_object_id(spot_id)
+    if not dbc.check_document_exist("_id", spot_id, "spots"):
+        return NOT_FOUND
     for factor in factorArgs:
-        update_individual_spot_factor(spot_id, factor, factorArgs[factor])
+        rating = int(factorArgs[factor]["factorValue"])
+        update_individual_spot_factor(spot_id, factor, rating)
+
     return spot_id
 
 
@@ -159,6 +164,8 @@ def add_review(spotID, reviewTitle, reviewText, reviewRating):
     }
     print("Create review object", review_object)
     response = dbc.create_review(spotID, review_object)
+    if not response:
+        return NOT_FOUND
     print("Add Review response: ", response)
     return response
 


### PR DESCRIPTION
# Pull Request 

## Description
Accidentally pushed to master for the delete error handling 
This PR looks at bad posts, gets, and puts. Also added tests for factors
For puts
- Tests puts for spot IDs that don't exist (put spot or put factor where the spot id doesn't exist)
-   Our put was not creating the object if it didn't exist so I continued this bad case by returning a 404
For gets 
- Tests get by spot IDs that don't exist (get spot detail by spot id or get review by spot id)
-   Returns 404 for poorly formatted ids and for IDs not found
For posts
- Tests post review with respect to a spot id
-   Returns a 404 if the spot id is poorly formatted or not found

When we use mongo's find for an id that doesn't exist, then it will give an empty cursor and not necessarily raise an error. 
So our error handling `except (pm.errors.CursorNotFound, InvalidId):` actually only checks for if the ID is bad or if the cursor dies during the operation. We still have to separately check if the cursor is empty.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Added `test_bad_post`, `test_bad_get_by_id`, `test_bad_put`
