### PR TITLE
Maintain review state on spot

### DIFF
--- a/API/endpoints.py
+++ b/API/endpoints.py
@@ -93,15 +93,12 @@ class SpotCreate(Resource):
         """
         Creates a new spot
         """
-        print("SpotCreate CAN THIS PRINT")
         args = spotParser.parse_args()
-        print(args)
         spot_response = db.add_spot(args['spotName'], args['spotAddress'],
                                     args['spotCapacity'], args['spotImage'])
         if spot_response == db.DUPLICATE:
             raise (wz.NotAcceptable("Spot already exists."))
         else:
-            print("SpotCreate", spot_response)
             return spot_response
 
 
@@ -200,9 +197,7 @@ class ReviewCreate(Resource):
         """
         Creates a new review
         """
-        print("ReviewCreate CAN THIS PRINT")
         args = reviewParser.parse_args()
-        print(args)
         review_response = db.add_review(args["spotID"],
                                         args['reviewTitle'],
                                         args['reviewText'],

--- a/API/tests/test_endpoints.py
+++ b/API/tests/test_endpoints.py
@@ -4,6 +4,7 @@ This file holds the tests for endpoints.py.
 
 from unittest import TestCase
 import API.endpoints as ep
+import json
 from API.security.utils import get_auth0_token, get_access_token_for_test_user
 
 userToken = "Bearer " + get_access_token_for_test_user() # this gives a token for the test user johndoe1 who has the admin role
@@ -41,6 +42,18 @@ class EndpointTestCase(TestCase):
             "factorAmbiance": self.factor_form
         }
     
+    def proper_spot_structure(self, spotDetail):
+        fields = ["_id"] + list(self.spotData.keys()) + list(self.factor.keys())
+        self.structure_test(fields, spotDetail)
+    
+    def proper_review_structure(self, reviewDetail):
+        fields = self.reviewData.keys()
+        self.structure_test(fields, reviewDetail)
+    
+    def structure_test(self, fields, detail):
+        for field in fields:
+            self.assertIn(field, detail)
+    
     def tearDown(self):
         print("Tear Down")
 
@@ -70,6 +83,8 @@ class EndpointTestCase(TestCase):
         response = self.client.get(f"/spots/{spot_id}", headers=self.headers)
         print("Test Get Spot Detail", response.data)
         self.assertEqual(response.status_code, 200)
+        spotDetail = json.loads(response.data.decode("utf-8"))
+        self.proper_spot_structure(spotDetail)
 
         response = self.client.put(f"/spots/update/{spot_id}", data=self.updatedSpotData, headers=self.headers)
         print("Test Update Spot", response.data)
@@ -78,7 +93,7 @@ class EndpointTestCase(TestCase):
         response = self.client.delete(f"/spots/delete/{spot_id}", headers=self.headers)
         print("Test Delete Spot", response.data)
         self.assertEqual(response.status_code, 200)
-        
+
     def test_review_crud(self):
         response = self.client.post("/spots/create", data=self.spotData, headers=self.headers)
         print(response.data)
@@ -96,6 +111,8 @@ class EndpointTestCase(TestCase):
         response = self.client.get(f"/spot_review/read/{spot_id}", headers=self.headers)
         print("Test Get Review", response.data)
         self.assertEqual(response.status_code, 200)
+        reviewDetail = json.loads(response.data.decode("utf-8"))[0]
+        self.proper_review_structure(reviewDetail)
 
         response = self.client.delete(f"/spot_review/delete/{review_id}", headers=self.headers)
         print("Test Delete Review", response.data)

--- a/db/data.py
+++ b/db/data.py
@@ -77,6 +77,9 @@ def get_spot_detail(spot_id):
     response = dbc.fetch_spot_details(spot_id)
     if response is None:
         return NOT_FOUND
+    reviews = get_review_by_spot(spot_id)
+    if reviews is not NOT_FOUND:
+        response["reviews"] = reviews
     return response
 
 

--- a/db/db_connect.py
+++ b/db/db_connect.py
@@ -177,19 +177,12 @@ def delete_spot(spot_id):
 def create_review(spotID, review_object):
     try:
         spotID = convert_to_object_id(spotID)
-        filter = {"_id": spotID}
         if not check_document_exist("_id", spotID, "spots"):
             return None
     except (pm.errors.CursorNotFound, InvalidId):
         return None
     response = client[DB_NAME]['reviews'].insert_one(review_object)
     print("Create Review", response)
-    new_values = {"$push": {
-        "reviews": review_object
-    }}
-    spot_update = client[DB_NAME]['spots'].update_one(filter, new_values)
-    LOG.info("Successfully updated spot" + str(spotID))
-    print(spot_update)
     return str(review_object["_id"])
 
 


### PR DESCRIPTION
# Pull Request 

## Description

Noticed that `reviews` list on the spot object from the get spot details endpoint did not match the reviews in the db. This is because we were setting reviews onto the spot object when creating them, but not removing them when deleting them. 
So instead of relying on the create review and delete review to maintain the proper state of the spot object, this PR calls `get_review_by_spot` and adds it into the spot response for get spot details.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Manually tested